### PR TITLE
[#153570220] Add MIT license to `qpdf` repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014 - 2017 Grand Rounds, Inc
+Copyright (c) Grand Rounds, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Grand Rounds, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Grand Rounds, Inc
+Copyright (c) 2014 - 2017 Grand Rounds, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/qpdf.gemspec
+++ b/qpdf.gemspec
@@ -1,12 +1,13 @@
 Gem::Specification.new do |g|
   g.name = 'qpdf'
-  g.version = '0.0.1'
-  g.date = '2014-03-27'
+  g.version = '0.0.2'
+  g.date = '2017-12-11'
   g.summary = 'Qpdf library for Rails'
   g.description = 'Qpdf is used for unlocking locked pdf files'
+  g.license = 'MIT'
   g.authors = ['Ken Berland', 'Justin Ahn', 'Brett Suwyn']
-  g.email = 'ken@grnds.com'
-  g.homepage = 'https://github.com/ConsultingMD/qdf.git'
+  g.email = 'brett@grnds.com'
+  g.homepage = 'https://github.com/ConsultingMD/qpdf.git'
   g.files = %w(README.md)
   g.files += Dir.glob("{lib,generators}/**/*")
   g.require_paths = ['lib']

--- a/qpdf.gemspec
+++ b/qpdf.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |g|
   g.authors = ['Ken Berland', 'Justin Ahn', 'Brett Suwyn']
   g.email = 'brett@grnds.com'
   g.homepage = 'https://github.com/ConsultingMD/qpdf.git'
-  g.files = %w(README.md)
+  g.files = %w(README.md LICENSE)
   g.files += Dir.glob("{lib,generators}/**/*")
   g.require_paths = ['lib']
   g.add_dependency('rails')


### PR DESCRIPTION
[#153570220](https://www.pivotaltracker.com/story/show/153570220)

Leaving years off is easier than using them; they're annotational only anyway. Changed email address to one that resolves :).  Bumped version since it *wasn't* bumped for the last PR we took.